### PR TITLE
feat[FZS-76]: Implementada rotas de CRUD para Solicitação de Folga

### DIFF
--- a/src/main/java/com/fromzero/checkpoint/controllers/SolicitacaoFolgaController.java
+++ b/src/main/java/com/fromzero/checkpoint/controllers/SolicitacaoFolgaController.java
@@ -1,0 +1,60 @@
+package com.fromzero.checkpoint.controllers;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fromzero.checkpoint.entities.Colaborador;
+import com.fromzero.checkpoint.entities.SolicitacaoFolga;
+import com.fromzero.checkpoint.repositories.ColaboradorRepository;
+import com.fromzero.checkpoint.repositories.SolicitacaoFolgaRepository;
+
+@RestController
+public class SolicitacaoFolgaController {
+	@Autowired
+	private SolicitacaoFolgaRepository repository;
+	
+	@Autowired
+	private ColaboradorRepository colaboradorRepository;
+	
+	@PostMapping("/solicitacao-folga")
+    public SolicitacaoFolga cadastrarSolicitacaoFolga(@RequestBody SolicitacaoFolga f) {
+        Colaborador colaborador = colaboradorRepository.findById(f.getColaborador().getId())
+            .orElseThrow(() -> new RuntimeException("Colaborador não encontrado"));
+        f.setColaborador(colaborador);
+        repository.save(f);  
+        return f;
+    }
+	
+    @GetMapping("/solicitacao-folga")
+    public List<SolicitacaoFolga> obterFaltas() {
+        return repository.findAll();
+    }
+    
+    @GetMapping("/solicitacao-folga/{id}")
+    public SolicitacaoFolga obterFalta(@PathVariable Long id) {
+        return repository.findById(id).get();
+    }
+    
+    @PutMapping("/solicitacao-folga/{id}")
+    public SolicitacaoFolga atualizarSolicitacaoFolga(@PathVariable Long id, @RequestBody SolicitacaoFolga solicitacaoAtualizada) {
+        
+        
+        SolicitacaoFolga f = repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Solicitação não encontrada"));
+        f.setSolFolData(solicitacaoAtualizada.getSolFolData());
+        return repository.save(f);
+    }
+    
+    @DeleteMapping("/solicitacao-folga/{id}")
+    public void deletarSolicitacaoFolga(@PathVariable Long id) {
+        repository.deleteById(id); // Uses JpaRepository's built-in delete method [[5]]
+    }
+}

--- a/src/main/java/com/fromzero/checkpoint/entities/Colaborador.java
+++ b/src/main/java/com/fromzero/checkpoint/entities/Colaborador.java
@@ -8,28 +8,31 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
 import lombok.Data;
 
 @Entity
+@Table(name = "colaborador")
 @Data
 public class Colaborador {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "col_id")
     private Long id;
 
-    @Column
+    @Column(name = "col_nome")
     private String nome;
 
-    @Column(unique = true, nullable = false)
+    @Column(name = "col_email", unique = true, nullable = false)
     private String email;
 
-    @Column
+    @Column(name = "col_senha")
     private String senhaHash;
 
-    @Column
+    @Column(name = "col_ativo")
     private Boolean ativo = true;
 
-    @Column
+    @Column(name = "criado_em")
     private LocalDateTime criadoEm;
 
     @PrePersist

--- a/src/main/java/com/fromzero/checkpoint/entities/SolicitacaoFolga.java
+++ b/src/main/java/com/fromzero/checkpoint/entities/SolicitacaoFolga.java
@@ -1,0 +1,53 @@
+package com.fromzero.checkpoint.entities;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import lombok.Data;
+
+@Entity
+@Data
+public class SolicitacaoFolga {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "sol_fol_id")
+	private Long solFolId;
+	
+	@Column(name = "sol_fol_data")
+	private LocalDate solFolData;
+	
+	@Column(name = "sol_fol_observacao")
+	private String solFolObservacao;
+	
+	public enum SolicitacaoStatus {
+        Aprovado,
+        Rejeitado,
+        Pendente
+    }
+	
+	@Enumerated(EnumType.STRING)
+	@Column(name = "sol_fol_status")
+    private SolicitacaoStatus status;
+	
+	@ManyToOne
+    @JoinColumn(nullable = false, name = "colaborador_id")
+    private Colaborador colaborador;
+	
+	@Column(name = "criado_em")
+    private LocalDateTime criadoEm;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.criadoEm == null) this.criadoEm = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/fromzero/checkpoint/repositories/SolicitacaoFolgaRepository.java
+++ b/src/main/java/com/fromzero/checkpoint/repositories/SolicitacaoFolgaRepository.java
@@ -1,0 +1,8 @@
+package com.fromzero.checkpoint.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.fromzero.checkpoint.entities.SolicitacaoFolga;
+
+public interface SolicitacaoFolgaRepository extends JpaRepository<SolicitacaoFolga, Long> {
+	
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=checkpoint
-spring.datasource.url=jdbc:mysql://localhost:3306/
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.url=jdbc:mysql://localhost:3306/CheckPointDBv2
+spring.datasource.username=root
+spring.datasource.password=pedro13
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 upload.dir=uploads/


### PR DESCRIPTION
## O que foi feito
- Adicionado rotas de CRUD para Solicitações do Folga
## O porquê
- Para completar a task fzs-76 para implementar funcionalidade de edição e exclusão de pedido de folga
## O que mudou
- Adição da Entidade SoliticacaoFolga
- Adição de um Controller que trata das rotas do CRUD da Entidade SoliticacaoFolga
- Edição da Entidade Colaborador para garantir o mapeamento correto no banco de dados